### PR TITLE
Allow "fish_directory" setting to accept a multi-platform dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+3.2.1 (ST3 only)
+----------------
+
+Settings change:
+- Allow `fish_directory` to be a dictionary with per-platform values in addition to a simple string
+
 3.2.0 (ST3 only)
 ----------------
 

--- a/Messages/news-3.2.1.md
+++ b/Messages/news-3.2.1.md
@@ -1,0 +1,4 @@
+News - 3.2.1
+============
+
+This release allows the `fish_directory` setting to be defined as a dictionary with per-platform values

--- a/Tools/misc.py
+++ b/Tools/misc.py
@@ -6,6 +6,12 @@ import subprocess
 # Check for command, expanding search to valid fish installs on Windows
 def commandOnAbsolutePath(command, settings):
   dirPath = settings.get('fish_directory')
+  if type(dirPath) is dict:
+    subl_os = sublime.platform()
+    if subl_os in dirPath:
+      dirPath = dirPath[subl_os]
+    else:
+      dirPath = None
 
   if not dirPath and sublime.platform() == 'windows':
     if sublime.arch() == 'x32':

--- a/fish.sublime-settings
+++ b/fish.sublime-settings
@@ -1,5 +1,11 @@
 {
   // Absolute file path to directory containing fish binaries (fish, fish_indent).
+  // A string or a dictionary keyed off sublime.platform() values, so it may be customized on a per-platform basis:
+    // "fish_directory": {
+    //   "windows": "C:/cygwin/bin",
+    //   "linux":   "/usr/local/bin/",
+    //   "osx":     "/usr/local/bin/"
+    // },
   // Only need to specify for nonstandard fish installs! On Windows, the Cygwin/MSYS2 arch is assumed to be the same as that of the system.
   // E.g., for a default 32-bit Cygwin install on 64-bit Windows you must set to "C:/cygwin/bin"
   "fish_directory": "",

--- a/messages.json
+++ b/messages.json
@@ -1,5 +1,6 @@
 {
   "3.0.1": "Messages/changes.md",
+  "3.2.1": "Messages/news-3.2.1.md",
   "3.2.0": "Messages/news-3.2.0.md",
   "3.1.0": "Messages/news-3.1.0.md",
   "3.0.0": "Messages/news-3.0.0.md",


### PR DESCRIPTION
It's common in Sublime Text for various path settings to accept dictionaries with per-platform paths to be able to have a single config file for various platforms, so this PR allows to do the same in the fish plugin

I've added the corresponding changelog/message items, but not sure it's worth a separate release, so might be better to change the number/file name to the actual release number whatever that might be